### PR TITLE
选区x轴拖动的边界限制

### DIFF
--- a/alloy-crop.js
+++ b/alloy-crop.js
@@ -116,11 +116,12 @@
                 pressMove: function (evt) {
                     var cr = self.img.getBoundingClientRect();
                     var boxOffY = (document.documentElement.clientHeight - self.height)/2;
-                    if((cr.left + evt.deltaX <= 0) && (cr.right + evt.deltaX >= self.width)){
-                        self.img.translateX += evt.deltaX;  
-                    }
                     if((boxOffY - cr.top - evt.deltaY >= 0) && (cr.bottom + evt.deltaY - boxOffY>= self.height)){
                         self.img.translateY += evt.deltaY;
+                    }
+                    var boxOffX = (document.documentElement.clientWidth - self.width)/2;
+                    if((cr.left + evt.deltaX <= boxOffX) && (cr.right + evt.deltaX - boxOffX >= self.width)){
+                        self.img.translateX += evt.deltaX;  
                     }
                     evt.preventDefault();
                 }


### PR DESCRIPTION
 
之前x轴选取不能正确限制在图片内

https://github.com/AlloyTeam/AlloyCrop/issues/19

![wechatimg402](https://user-images.githubusercontent.com/17024745/39967470-32aa5594-56ee-11e8-9ccb-bedf39ee5709.jpeg)
