### PR TITLE
修复手机裁剪宽高问题，获取正确的大小，恢复正常缩放比例。

### DIFF
--- a/alloy-crop.js
+++ b/alloy-crop.js
@@ -61,8 +61,8 @@
     AlloyCrop.prototype = {
         init: function () {
 
-            this.img_width = this.img.width;
-            this.img_height = this.img.height;
+            this.img_width = this.img.naturalWidth;
+            this.img_height = this.img.naturalHeight;
             Transform(this.img,true);
             var scaling_x = window.innerWidth / this.img_width,
                 scaling_y = window.innerHeight / this.img_height;


### PR DESCRIPTION
顺便说下假如裁剪时候显示空白或什么都没有，可能img有全局样式，请检查你的样式有没冲突。
被队友坑了，注意！！！